### PR TITLE
socket_ncs: remove deprecated nrf_modem AT socket 

### DIFF
--- a/include/net/socket_ncs.h
+++ b/include/net/socket_ncs.h
@@ -16,17 +16,7 @@
 extern "C" {
 #endif
 
-/* NCS specific protocol/address families. */
-
-#define PF_LTE 102 /**< Protocol family specific to LTE. */
-#define AF_LTE PF_LTE /**< Address family specific to LTE. */
-
 /* NCS specific protocol types. */
-
-/** Protocol numbers for LTE protocols */
-enum net_lte_protocol {
-	NPROTO_AT = 513,
-};
 
 /** Protocol numbers for LOCAL protocols */
 enum net_local_protocol {


### PR DESCRIPTION
The AT socket has been removed from the modem library after being deprecated
for two subsequent releases. These AT socket related macros are therefore
no longer required.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>