### PR TITLE
fixup! [nrf-noup] include: net: add NCS extension

### DIFF
--- a/include/zephyr/net/socket_ncs.h
+++ b/include/zephyr/net/socket_ncs.h
@@ -98,6 +98,8 @@ extern "C" {
 #define SO_IP_ECHO_REPLY 31
 /** sockopt: disable IPv6 ICMP replies */
 #define SO_IPV6_ECHO_REPLY 32
+/** sockopt: enable sending data as part of exceptional events */
+#define SO_EXCEPTIONAL_DATA 33
 /** sockopt: bind to PDN */
 #define SO_BINDTOPDN 40
 /** sockopt: Release Assistance Indication feature: This will indicate that the


### PR DESCRIPTION
Add support for `SO_EXCEPTIONAL_DATA` socket option to enable sending data as part of exceptional events (3GPP).